### PR TITLE
Fix test in org.eclipse.compare.tests #525

### DIFF
--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FilterTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/FilterTest.java
@@ -61,9 +61,9 @@ public class FilterTest {
 
 	@Test
 	public void testVerify() {
-		// Assert.assertNull("filters don't verify",
-		// Filter.validateResourceFilters("*.class, .cvsignore, bin/"));
-		// Assert.assertNotNull("filters shouldn't verify",
-		// Filter.validateResourceFilters("bin//"));
+		 Assert.assertNull("filters don't verify",
+		 CompareResourceFilter.validateResourceFilters("*.class, .cvsignore, bin/"));
+		 Assert.assertNotNull("filters shouldn't verify",
+		 CompareResourceFilter.validateResourceFilters("bin//"));
 	}
 }


### PR DESCRIPTION
This commit reactivates and fixes the test testVerify() from FilterTest.java in org.eclipse.compare.tests. The test was outcommented in the past probably because Filter.validateResourceFilters(String) could not be performed anymore. Now validateResourceFilters(String) is performed on CompareResourceFilter. Contributes to #525.