### PR TITLE
Fixes TipImageTests in org.eclipse.tips.tests #525

### DIFF
--- a/ua/org.eclipse.tips.core/src/org/eclipse/tips/core/TipImage.java
+++ b/ua/org.eclipse.tips.core/src/org/eclipse/tips/core/TipImage.java
@@ -42,7 +42,7 @@ public class TipImage {
 	private final URL fURL;
 	private double fAspectRatio = THREE_TO_TWO;
 
-	private final String fBase64Image;
+	private String fBase64Image;
 
 	/**
 	 * Creates a new TipImage with the specified URL which gets read into a base 64
@@ -82,7 +82,6 @@ public class TipImage {
 	 *
 	 * @param base64Image
 	 *            the non-null base64 encoded image according to RFC-2397.
-	 *
 	 * @throws RuntimeException
 	 *             if the string is not valid
 	 * @see TipImage
@@ -97,7 +96,6 @@ public class TipImage {
 			fBase64Image = base64Image;
 			int from = base64Image.indexOf('/') + 1;
 			int to = base64Image.indexOf(';');
-			setExtension(base64Image.substring(from, to).trim());
 			setExtension(base64Image.substring(from, to).trim());
 		} else {
 			int length = base64Image.length();
@@ -205,15 +203,16 @@ public class TipImage {
 
 	/**
 	 * Changes the default value "null" to the passed value which commonly is "png",
-	 * "gif" and such.
+	 * "gif" and such. It also updates the Base64Image to properly include the new
+	 * extension.
 	 *
-	 * @param extension
-	 *            the extension of this file
+	 * @param newExtension the new extension of this file
 	 * @return this
 	 * @see #getExtension()
 	 */
-	public TipImage setExtension(String extension) {
-		fExtension = extension;
+	public TipImage setExtension(String newExtension) {
+		fBase64Image = fBase64Image.replaceAll("/.*;", "/" + newExtension + ";"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		fExtension = newExtension;
 		return this;
 	}
 

--- a/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipImageBas64Test.java
+++ b/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipImageBas64Test.java
@@ -41,13 +41,12 @@ public class TipImageBas64Test {
 
 	@Test
 	public void testSetExtension() {
-		// assertTrue(getTipImage().getIMGAttributes(19, 10).contains("png"));
+		assertTrue(getTipImage().getBase64Image().contains("png"));
 	}
 
 	@Test
 	public void testSetExtension2() {
-		// assertTrue(getTipImage().setExtension("bmp").getBase64Image().contains("bmp"));
-		// assertTrue(getTipImage().getIMGAttributes(19, 10).contains("png"));
+		assertTrue(getTipImage().setExtension("bmp").getBase64Image().contains("bmp"));
 	}
 
 	@Test

--- a/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipImageURLTest.java
+++ b/ua/org.eclipse.tips.tests/src/org/eclipse/tips/core/TipImageURLTest.java
@@ -95,13 +95,12 @@ public class TipImageURLTest {
 	}
 
 	@Test
-	public void testSetExtension() {
-		// assertTrue(getTipImage().getIMGAttributes(19, 10).contains("png"));
+	public void testSetExtension() throws IOException {
+		assertTrue(getTipImage().getBase64Image().contains("png"));
 	}
 
 	@Test
-	public void testSetExtension2() {
-		// assertTrue(getTipImage().setExtension("bmp").getBase64Image().contains("bmp"));
-		// assertTrue(getTipImage().getIMGAttributes(19, 10).contains("png"));
+	public void testSetExtension2() throws IOException {
+		assertTrue(getTipImage().setExtension("bmp").getBase64Image().contains("bmp"));
 	}
 }


### PR DESCRIPTION
The content of the 4 disabled tests was very random before the change. There are 3 possibilities to deal with those tests:
1. Just delete the tests completely (which feels best for me)
2. Only test if setExtension has really set the extension by calling getExtension afterwards. (is very trivial and works only if the URL constructor was used because of the bad implementation of getExtension)
3. Use the solution presented in this PR (my problem with this solution is that it changes the too much of the old behavior and especially that the fields fURL and fBase64Image cannot be final anymore)

Can you please give me feedback to this?